### PR TITLE
Run refund and cancel jobs every 30 min by default

### DIFF
--- a/metadata/jobs.xml
+++ b/metadata/jobs.xml
@@ -15,8 +15,8 @@
             <run-recurring enabled="true">
                 <recurrence>
                     <date-from>2023-01-01Z</date-from>
-                    <start-time>14:00:00.000Z</start-time>
-                    <interval>1d</interval>
+                    <start-time>00:00:00.000Z</start-time>
+                    <interval>30m</interval>
                     <day-of-week/>
                 </recurrence>
             </run-recurring>
@@ -39,7 +39,7 @@
                 <recurrence>
                     <date-from>2023-01-01Z</date-from>
                     <start-time>00:00:00.000Z</start-time>
-                    <interval>1h</interval>
+                    <interval>30m</interval>
                     <day-of-week/>
                 </recurrence>
             </run-recurring>


### PR DESCRIPTION
## Description

This updates the default job schedule to run refund and cancel processes every 30 minutes per product requirement, instead of 1 day and 1 hour respectively as of now.

