### PR TITLE
Save KOMOJU payment ID on capture webhook and add session ID fallback

### DIFF
--- a/cartridges/app_komoju_controllers/cartridge/controllers/KomojuController.js
+++ b/cartridges/app_komoju_controllers/cartridge/controllers/KomojuController.js
@@ -567,7 +567,7 @@ function HandleWebHooksCaptureComplete() {
             order.custom.komojuPaymentId = paymentIdKomoju;
         });
     } catch (e) {
-        Logger.error('Error saving paymentId ' + e.toString() + ' in ' + e.fileName + ':' + e.lineNumber);
+        Logger.error('Error saving paymentId in HandleWebHooksCaptureComplete: ' + e.toString());
     }
 
     var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju);

--- a/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
+++ b/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
@@ -665,7 +665,7 @@ server.post('HandleWebHooksCaptureComplete', function (req, res, next) {
             order.custom.komojuPaymentId = paymentIdKomoju;
         });
     } catch (e) {
-        Logger.error('Error saving paymentId ' + e.toString() + ' in ' + e.fileName + ':' + e.lineNumber);
+        Logger.error('Error saving paymentId in HandleWebHooksCaptureComplete: ' + e.toString());
     }
 
     var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju);

--- a/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
+++ b/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
@@ -268,8 +268,6 @@ server.get('geturl', function (req, res, next) {
     });
     return next();
 });
-
-
 server.get('KomojuOrder', csrfProtection.generateToken, server.middleware.https, function (req, res, next) {
     var BasketMgr = require('dw/order/BasketMgr');
     var URLUtils = require('dw/web/URLUtils');
@@ -650,6 +648,7 @@ server.post('HandleWebHooksRefund', function (req, res, next) {
 });
 server.post('HandleWebHooksCaptureComplete', function (req, res, next) {
     var Order = require('dw/order/Order');
+    var customKomojuSourceLogger = Logger.getLogger('customKomojuSourceLogger', 'customKomojuSourceLogger');
 
     var paymentIdKomoju = JSON.parse(req.body).data.id;
     var body = JSON.parse(req.body);
@@ -661,7 +660,24 @@ server.post('HandleWebHooksCaptureComplete', function (req, res, next) {
 
     var webhookCallVerified = komojuHelpers.verifyWebhookCall(bodyToEncode, komojuSignature);
 
+    try {
+        Transaction.wrap(function () {
+            order.custom.komojuPaymentId = paymentIdKomoju;
+        });
+    } catch (e) {
+        Logger.error('Error saving paymentId ' + e.toString() + ' in ' + e.fileName + ':' + e.lineNumber);
+    }
+
     var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju);
+
+    // Fallback to session id
+    if (!komojuOrder) {
+        var sessionIdKomoju = JSON.parse(req.body).data.session;
+        komojuOrder = OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
+    }
+
+    customKomojuSourceLogger.info("Komoju Order: " + (komojuOrder ? komojuOrder.orderNo : "No order found"));
+
     if (komojuOrder) {
         orderStatus = komojuOrder.getStatus().toString();
     }
@@ -687,6 +703,7 @@ server.post('HandleWebHooksCaptureComplete', function (req, res, next) {
     return next();
 });
 server.post('HandleWebHooksCancelled', function (req, res, next) {
+    var customKomojuSourceLogger = Logger.getLogger('customKomojuSourceLogger', 'customKomojuSourceLogger');
     var bodyToEncode = req.body;
     var body = JSON.parse(req.body);
     var komojuSignature = req.httpHeaders['x-komoju-signature'];
@@ -694,6 +711,14 @@ server.post('HandleWebHooksCancelled', function (req, res, next) {
     var webhookCallVerified = komojuHelpers.verifyWebhookCall(bodyToEncode, komojuSignature);
     var paymentIdKomoju = JSON.parse(req.body).data.id;
     var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju);
+
+    // Fallback to session id
+    if (!komojuOrder) {
+        sessionIdKomoju = JSON.parse(req.body).data.session;
+        komojuOrder = OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
+    }
+
+    customKomojuSourceLogger.info("Komoju Order: " + (komojuOrder ? komojuOrder.orderNo : "No order found"));
 
     if (komojuOrder) {
         if (webhookCallVerified) {

--- a/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
+++ b/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
@@ -714,7 +714,7 @@ server.post('HandleWebHooksCancelled', function (req, res, next) {
 
     // Fallback to session id
     if (!komojuOrder) {
-        sessionIdKomoju = JSON.parse(req.body).data.session;
+        var sessionIdKomoju = JSON.parse(req.body).data.session;
         komojuOrder = OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
     }
 


### PR DESCRIPTION
**Overview**
This pull request addresses an edge case where orders processed via KOMOJU (e.g. PayPay) were missing payment IDs when users closed the payment page or were not redirected back to the storefront (SFCC) immediately after completing payment.

**Problem**
In some cases, users complete the payment on the external payment app (e.g. PayPay) but close the tab or app after the payment was completed but before being redirected to the SFCC thank-you page. When this happens, the KOMOJU payment ID was not stored on the order, preventing certain webhooks, such as payment capture, from being processed correctly.

**Solution**
Webhook responses from KOMOJU now update the order with the appropriate KOMOJU payment ID, even if the redirect step is skipped. This ensures every successfully paid order has a valid and traceable payment ID, regardless of the user's post-payment behavior.