### PR TITLE
Correctly define order before trying to save paymentIdKomoju

### DIFF
--- a/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
+++ b/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
@@ -649,31 +649,30 @@ server.post('HandleWebHooksRefund', function (req, res, next) {
 server.post('HandleWebHooksCaptureComplete', function (req, res, next) {
     var Order = require('dw/order/Order');
     var customKomojuSourceLogger = Logger.getLogger('customKomojuSourceLogger', 'customKomojuSourceLogger');
-
     var paymentIdKomoju = JSON.parse(req.body).data.id;
     var body = JSON.parse(req.body);
     var paymentInstrument;
     var orderStatus;
-
     var bodyToEncode = req.body;
     var komojuSignature = req.httpHeaders['x-komoju-signature'];
-
     var webhookCallVerified = komojuHelpers.verifyWebhookCall(bodyToEncode, komojuSignature);
-
-    try {
-        Transaction.wrap(function () {
-            order.custom.komojuPaymentId = paymentIdKomoju;
-        });
-    } catch (e) {
-        Logger.error('Error saving paymentId in HandleWebHooksCaptureComplete: ' + e.toString());
-    }
-
     var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju);
 
     // Fallback to session id
     if (!komojuOrder) {
         var sessionIdKomoju = JSON.parse(req.body).data.session;
         komojuOrder = OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
+
+        // Save komojuPaymentId to order since we had to fallback to session id
+        if (komojuOrder) {
+            try {
+                Transaction.wrap(function () {
+                    komojuOrder.custom.komojuPaymentId = paymentIdKomoju;
+                });
+            } catch (e) {
+                customKomojuSourceLogger.error('Error saving paymentId in HandleWebHooksCaptureComplete: ' + e.toString());
+            }
+        }
     }
 
     customKomojuSourceLogger.info("Komoju Order: " + (komojuOrder ? komojuOrder.orderNo : "No order found"));

--- a/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
+++ b/cartridges/int_komoju_sfra/cartridge/controllers/KomojuController.js
@@ -656,32 +656,23 @@ server.post('HandleWebHooksCaptureComplete', function (req, res, next) {
     var bodyToEncode = req.body;
     var komojuSignature = req.httpHeaders['x-komoju-signature'];
     var webhookCallVerified = komojuHelpers.verifyWebhookCall(bodyToEncode, komojuSignature);
-    var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju);
-
-    // Fallback to session id
-    if (!komojuOrder) {
-        var sessionIdKomoju = JSON.parse(req.body).data.session;
-        komojuOrder = OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
-
-        // Save komojuPaymentId to order since we had to fallback to session id
-        if (komojuOrder) {
-            try {
-                Transaction.wrap(function () {
-                    komojuOrder.custom.komojuPaymentId = paymentIdKomoju;
-                });
-            } catch (e) {
-                customKomojuSourceLogger.error('Error saving paymentId in HandleWebHooksCaptureComplete: ' + e.toString());
-            }
-        }
-    }
-
+    var sessionIdKomoju = body.data.session;
+    var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju) || OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
+ 
     customKomojuSourceLogger.info("Komoju Order: " + (komojuOrder ? komojuOrder.orderNo : "No order found"));
 
     if (komojuOrder) {
-        orderStatus = komojuOrder.getStatus().toString();
-    }
-    if (komojuOrder) {
+        try {
+            Transaction.wrap(function () {
+                komojuOrder.custom.komojuPaymentId = paymentIdKomoju;
+            });
+        } catch (e) {
+            customKomojuSourceLogger.error('Error saving paymentId in HandleWebHooksCaptureComplete: ' + e.toString());
+        }
+
         if (webhookCallVerified) {
+            orderStatus = komojuOrder.getStatus().toString();
+
             Transaction.wrap(function () {
                 if (komojuOrder && orderStatus === 'CREATED') {
                     OrderMgr.placeOrder(komojuOrder);
@@ -709,13 +700,8 @@ server.post('HandleWebHooksCancelled', function (req, res, next) {
 
     var webhookCallVerified = komojuHelpers.verifyWebhookCall(bodyToEncode, komojuSignature);
     var paymentIdKomoju = JSON.parse(req.body).data.id;
-    var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju);
-
-    // Fallback to session id
-    if (!komojuOrder) {
-        var sessionIdKomoju = JSON.parse(req.body).data.session;
-        komojuOrder = OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
-    }
+    var sessionIdKomoju = body.data.session;
+    var komojuOrder = OrderMgr.searchOrder('custom.komojuPaymentId = {0}', paymentIdKomoju) || OrderMgr.searchOrder('custom.komojuSessionId = {0}', sessionIdKomoju);
 
     customKomojuSourceLogger.info("Komoju Order: " + (komojuOrder ? komojuOrder.orderNo : "No order found"));
 


### PR DESCRIPTION
We were trying to update the custom `komojuPaymentId` before the order was defined. Update the logic in the webhook to properly define and find the order before attempting to save the ID.